### PR TITLE
Update self-help documentation link

### DIFF
--- a/src/plugins/miradorHelpDialog.js
+++ b/src/plugins/miradorHelpDialog.js
@@ -64,12 +64,12 @@ export class harvardHelpDialog extends Component {
         <DialogContent>         
           <List>
             <ListItem className={classes.helpItem}>
-              <ListItemLink href="https://wiki.harvard.edu/confluence/display/LibraryStaffDoc/Harvard+Library+Viewer" target="_blank" rel="noopener">
+              <ListItemLink href="https://ask.library.harvard.edu/faq/392399" target="_blank" rel="noopener">
                 <ListItemIcon>
                   <DescriptionIcon />
                 </ListItemIcon>
                 <ListItemText>
-                  Read documentation
+                  Using the Viewer
                   <Typography variant="srOnly">(opens in a new tab)</Typography>
                 </ListItemText>
               </ListItemLink>


### PR DESCRIPTION
**Update self-help documentation link**

---

**JIRA Ticket**: [LTSVIEWER-92](https://jira.huit.harvard.edu/browse/LTSVIEWER-92)

# What does this Pull Request do?

Renames the self-help documentation link and updates it to point to the LibAnswers knowledge base article

# How should this be tested?

* Spin up the demo site from this branch: `npm run serve`
* Open the "Help" modal window
* Confirm that the first list item reads "Using the Viewer" and points to https://ask.library.harvard.edu/faq/392399

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz @phil-plencner-hl @f8f8ff 
